### PR TITLE
Fix configs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ A Neovim plugin that adds search history functionality to Telescope's live_grep 
 
 ```lua
 -- Load the extension
-require('telescope').load_extension('live_grep_history')
+require('telescope').load_extension('livegrep_history')
 
 -- Optional: Configure the extension
 require('telescope').setup {
   extensions = {
-    live_grep_history = {
+    livegrep_history = {
       -- Customize key mappings
       mappings = {
         up_key = "<Up>",      -- Navigate to older search history
@@ -59,7 +59,7 @@ require('telescope').setup {
 
 ```lua
 -- Example keymapping
-vim.keymap.set('n', '<leader>gg', require('telescope').extensions.live_grep_history.live_grep_with_history)
+vim.keymap.set('n', '<leader>gg', require('telescope').extensions.livegrep_history.live_grep_with_history)
 ```
 
 ### Default Mappings


### PR DESCRIPTION
Hi, thankya much for making this extension; just wanted to lyk that the default config from the readme doesn't work, since the lua module has the substring "livegrep" instead of "live_grep". An alternative solution would be changing the extension's name, but then you might wanna change the repo's name (if you are insanely anal about punctuation), so that seems like more of a hassle. =3